### PR TITLE
feat: implement rename lifecycle function

### DIFF
--- a/transformations/__tests__/rename-lifecycle.spec.ts
+++ b/transformations/__tests__/rename-lifecycle.spec.ts
@@ -1,0 +1,32 @@
+import { defineInlineTest } from 'jscodeshift/src/testUtils'
+
+const renameLifeCycle = require('../rename-lifecycle')
+
+defineInlineTest(
+  renameLifeCycle,
+  {},
+  `export default {
+    destroyed: function () {
+      console.log('foo')
+    },
+    beforeDestroy: function () {
+      console.log('bar')
+    },
+    methods: {
+      destroyed: function() {},
+      beforeDestroy: function() {}
+    }
+}
+`,
+  `export default {
+    unmounted: function () {
+      console.log('foo')
+    },
+    beforeUnmount: function () {
+      console.log('bar')
+    },
+    methods: {
+      destroyed: function() {},
+      beforeDestroy: function() {}
+    }
+}`)

--- a/transformations/index.ts
+++ b/transformations/index.ts
@@ -17,6 +17,7 @@ const transformationMap: {
   'scoped-slots-to-slots': require('./scoped-slots-to-slots'),
   'new-directive-api': require('./new-directive-api'),
   'remove-vue-set-and-delete': require('./remove-vue-set-and-delete'),
+  'rename-lifecycle': require('./rename-lifecycle'),
 
   // atomic ones
   'remove-contextual-h-from-render': require('./remove-contextual-h-from-render'),

--- a/transformations/rename-lifecycle.ts
+++ b/transformations/rename-lifecycle.ts
@@ -1,0 +1,28 @@
+import wrap from '../src/wrapAstTransformation'
+import type { ASTTransformation } from '../src/wrapAstTransformation'
+
+const lifecycleMap: { [key: string]: string } = {
+  'destroyed': 'unmounted',
+  'beforeDestroy': 'beforeUnmount'
+}
+
+export const transformAST: ASTTransformation = ({ root, j }) => {
+  const methodArray: any [] = [j.ObjectProperty, j.ObjectMethod, j.ClassProperty]
+  methodArray.forEach(method => {
+    const methods = root.find(method)
+    if (methods.length) {
+      methods.forEach((path) => {
+        // @ts-ignore
+        const beforeReplaceName = path.node.key.name
+        const afterReplaceName = lifecycleMap[beforeReplaceName]
+        if (afterReplaceName && path.parent?.parent?.value?.type === 'ExportDefaultDeclaration') {
+          // @ts-ignore
+          path.value.key.name = afterReplaceName
+        }
+      })
+    }
+  })
+}
+
+export default wrap(transformAST)
+export const parser = 'babylon'


### PR DESCRIPTION
+ The destroyed lifecycle option has been renamed to unmounted
+ The beforeDestroy lifecycle option has been renamed to beforeUnmount

referenced at : https://v3.vuejs.org/guide/migration/introduction.html#other-minor-changes