### PR TITLE
Update jscodeshift to resolve a security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@vue/compiler-dom": "^3.0.5",
     "debug": "^4.1.1",
     "globby": "^11.0.2",
-    "jscodeshift": "^0.11.0",
+    "jscodeshift": "^0.13.1",
     "lru-cache": "^6.0.0",
     "source-map": "^0.6.1",
     "yargs": "^16.2.0"


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for `>1.4.0`, offending packages being `1.4.1`, `1.4.44-liberty`

* [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
* [source2](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the `jscodeshift` dependency to use version 0.13.1 which removed the dependency on `colors`

Ran the `build` and `test` scripts to verify functionality. All tests passed.